### PR TITLE
Add missing 'Reset Counter' to reset_counter.robot template

### DIFF
--- a/python/robot_framework.md
+++ b/python/robot_framework.md
@@ -192,6 +192,7 @@ Reset Counter After Several Increments
     Counter Value Should Be  0
     Increment Counter By  5
     Counter Value Should Be  5
+    Reset Counter
     Counter Value Should Be  0
 ```
 

--- a/python/robot_framework.md
+++ b/python/robot_framework.md
@@ -176,7 +176,7 @@ Lisää _src/tests_-hakemistoon tiedosto <i>reset_counter.robot</i>, joka sisäl
 
 **Lisää tiedostoon seuraavat testitapaukset:**
 
-```
+```text
 *** Settings ***
 Resource  resource.robot
 
@@ -198,7 +198,7 @@ Reset Counter After Several Increments
 
 Siirry virtuaaliympäristöön komennolla `poetry shell` ja suorita siellä komento `robot src/tests`. Testit eivät mene läpi ja tulosteessa on seuraava virhe:
 
-```
+```text
 No keyword with name 'Reset Counter' found.
 ```
 


### PR DESCRIPTION
I **think** there should be `Reset Counter` (if this is not any kind of trick question).