### PR TITLE
Poista kaksinkertainen tulostus

### DIFF
--- a/tehtavat7.md
+++ b/tehtavat7.md
@@ -142,11 +142,10 @@ Erilliset pelit sitten perivät abstraktin luokan ja erikoistavat sitä tarpiden
 ```java
 public class KPSPelaajaVsPelaaja extends KiviPaperiSakset {
 
-    // funktio pelaa peritääm
+    // funktio pelaa peritään
 
     @Override
     protected String toisenSiirto() {
-        System.out.print("Toisen pelaajan siirto: ");
         return scanner.nextLine();  
     }
 


### PR DESCRIPTION
Jos poistettu rivi olisi mukana, tulisi tuloste "Toisen pelaajan siirto: " kahteen kertaan kun pelataan ihminen vs ihminen.