### PR TITLE
Vastauksen lista ei vastaa kyselyä

### DIFF
--- a/python/tehtavat6.md
+++ b/python/tehtavat6.md
@@ -160,16 +160,16 @@ Kyselyn:
 
 ```java
 matcher = And(
-    HasAtLeast(20, "points"),
+    HasAtLeast(50, "points"),
     Or(
         PlaysIn("NYR"),
         PlaysIn("NYI"),
-        PlaysIn("NJD")
+        PlaysIn("BOS")
     )
 )
 ```
 
-Tulee palauttaa kaikki yli 20 pistettä tehneet jotka pelaavat jossain seuraavista joukkueista _NYI_, _NYR_ tai _NJD_. Lista näyttää seuraavalta:
+Tulee palauttaa kaikki yli 50 pistettä tehneet jotka pelaavat jossain seuraavista joukkueista _NYI_, _NYR_ tai _BOS_. Lista näyttää seuraavalta:
 
 ```
 Brock Nelson         NYI          26 + 28 = 54


### PR DESCRIPTION
Tehtävän kysely hakee kaikki pelaajat, joilla on enemmän kuin 20 pistettä joukkueista NYI, NYR, NJD. 
Vastaus on kuitenkin kaikki pelaajat, joilla on enemmän kuin 50 pistettä joukkueista NYI, NYR, BOS.

Eli muutetaan tehtävää vastaamaan vastausta.